### PR TITLE
add slashes to escape text values

### DIFF
--- a/Tool/FixtureGenerator.php
+++ b/Tool/FixtureGenerator.php
@@ -271,7 +271,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
                 } elseif (is_null($value)) {
                     $setValue = "NULL";
                 } else {
-                    $setValue = '"' . $value . '"';
+                    $setValue = 'stripslashes("' . addslashes($value) . '")';
                 }
 
                 $code .= "\n<spaces><spaces>{$comment}\$item{$id}->{$setter}({$setValue});";


### PR DESCRIPTION
Hey,

I "addslashed" the `$value` in `generateFixtureItemStub($item)` function to support database text values containing double quotes. It prevent syntax errors in generated fixtures classes.