### PR TITLE
Check if the semicolon in namespace already exists before adding it

### DIFF
--- a/Tool/FixtureGenerator.php
+++ b/Tool/FixtureGenerator.php
@@ -273,7 +273,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
                 } else {
                     $setValue = "<<<'EOT'\n$value\nEOT" . PHP_EOL;
                 }
-
                 $code .= "\n<spaces><spaces>{$comment}\$item{$id}->{$setter}({$setValue});";
             }
         }
@@ -492,7 +491,11 @@ use Doctrine\ORM\Mapping\ClassMetadata;
      */
     protected function generateFixtureNamespace()
     {
-        return 'namespace ' . $this->getNamespace() . ';';
+        $namespace = 'namespace ' . $this->getNamespace();
+        if (strpos($namespace, ';')) {
+            return $namespace;
+        }
+        return $namespace . ';';
     }
 
     protected function generateFixtures()

--- a/Tool/FixtureGenerator.php
+++ b/Tool/FixtureGenerator.php
@@ -492,10 +492,10 @@ use Doctrine\ORM\Mapping\ClassMetadata;
     protected function generateFixtureNamespace()
     {
         $namespace = 'namespace ' . $this->getNamespace();
-        if (strpos($namespace, ';')) {
-            return $namespace;
+        if (strpos($namespace, ';') === false) {
+            $namespace . ';';
         }
-        return $namespace . ';';
+        return $namespace;
     }
 
     protected function generateFixtures()


### PR DESCRIPTION
Hey,

Thank you for this bundle, i saved a lot of time thanks to it.

However, i had to remove one semicolon in every file genrated in the namespace like this one : "namespace Acseo\CoreBundle\DataFixture\ORM;;". Then i decided to change that.

Let me know if it's useful !