### PR TITLE
Make entity argument not require

### DIFF
--- a/Command/GenerateDoctrineFixtureCommand.php
+++ b/Command/GenerateDoctrineFixtureCommand.php
@@ -54,7 +54,7 @@ class GenerateDoctrineFixtureCommand extends GenerateDoctrineCommand
             ->addOption(
                 'entity',
                 null,
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_NONE,
                 'The entity class name to initialize (shortcut notation)'
             )
             ->addOption('snapshot', null, InputOption::VALUE_NONE, 'Create a full snapshot of DB.')


### PR DESCRIPTION
In fact, the interactive mode is triggered anyway, so, no need to have an error when not giving an --entity option.