### PR TITLE
Fixed issue when entity does not have constructor

### DIFF
--- a/Tool/FixtureGenerator.php
+++ b/Tool/FixtureGenerator.php
@@ -659,9 +659,9 @@ use Doctrine\ORM\Mapping\ClassMetadata;
         if ($propertyAnnotation !== null && $propertyAnnotation->ignoreInSnapshot === true) {
             //ignore this mapping. (data will not be exported for that field.)
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     protected function generateUse()
@@ -721,6 +721,10 @@ use Doctrine\ORM\Mapping\ClassMetadata;
      */
     private function getConstructorParams($item, \ReflectionClass $reflexion): array
     {
+        if (is_null($reflexion->getConstructor())) {
+            return [];
+        }
+
         $constructorParams = [];
         foreach ($reflexion->getConstructor()->getParameters() as $parameter) {
             if ($parameter->isDefaultValueAvailable()) {


### PR DESCRIPTION
If entity does not have constructor error from image is presented. This pull request resolves that issue.

![screenshot-20181226201021-840x268](https://user-images.githubusercontent.com/781417/50454836-58968480-094a-11e9-8ca4-faf04b9152f8.png)
