### PR TITLE
Load bundle configuration in build method, fixes #55

### DIFF
--- a/DoctrineFixturesGeneratorBundle.php
+++ b/DoctrineFixturesGeneratorBundle.php
@@ -9,11 +9,13 @@ use Symfony\Component\Config\FileLocator;
 
 class DoctrineFixturesGeneratorBundle extends Bundle
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function build(ContainerBuilder $container)
     {
+        parent::build($container);
+
         $loader = new YamlFileLoader(
             $container,
-            new FileLocator(__DIR__.'/../Resources/config')
+            new FileLocator(__DIR__.'/Resources/config')
         );
         $loader->load('services.yaml');
     }


### PR DESCRIPTION
This makes the `doctrine:generate:fixture` available and usable on Symfony `4.2`.

I made this hasty fix by looking at the configuration of other bundles that successfully register commands on Symfony `4.2`.

I did not have time to research best practices or whether using `build()` instead of `load()` is recommended.