### PR TITLE
Fixing incompatible interface

### DIFF
--- a/Generator/DoctrineFixtureGenerator.php
+++ b/Generator/DoctrineFixtureGenerator.php
@@ -14,9 +14,9 @@ namespace Webonaute\DoctrineFixturesGeneratorBundle\Generator;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
 use Webonaute\DoctrineFixturesGeneratorBundle\Command\GenerateDoctrineFixtureCommand;
 use Webonaute\DoctrineFixturesGeneratorBundle\Generator\Generator;
-use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Webonaute\DoctrineFixturesGeneratorBundle\Tool\FixtureGenerator;
@@ -35,7 +35,7 @@ class DoctrineFixtureGenerator extends Generator
     private $filesystem;
 
     /**
-     * @var RegistryInterface
+     * @var ManagerRegistry
      */
     private $registry;
 
@@ -43,9 +43,9 @@ class DoctrineFixtureGenerator extends Generator
      * Constructor
      *
      * @param Filesystem $filesystem
-     * @param RegistryInterface $registry
+     * @param ManagerRegistry $registry
      */
-    public function __construct(Filesystem $filesystem, RegistryInterface $registry)
+    public function __construct(Filesystem $filesystem, ManagerRegistry $registry)
     {
         $this->filesystem = $filesystem;
         $this->registry = $registry;

--- a/Tool/FixtureGenerator.php
+++ b/Tool/FixtureGenerator.php
@@ -366,7 +366,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
                     } else {
                         $setValue = "false";
                     }
-                } elseif ($value instanceof \DateTime) {
+                } elseif ($value instanceof \DateTimeInterface) {
                     $setValue = "new \\DateTime(\"" . $value->format("Y-m-d H:i:s") . "\")";
                 } elseif (is_object($value) && !($value instanceof PersistentCollection)
                     //$value != "Doctrine\\ORM\\PersistentCollection"

--- a/Tool/FixtureGenerator.php
+++ b/Tool/FixtureGenerator.php
@@ -85,7 +85,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 <spaces> */
 <spaces>public function load(ObjectManager $manager)
 <spaces>{
-<spaces><spaces>$manager->getClassMetadata(<entityName>::class)->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
+<spaces><spaces>//$manager->getClassMetadata(<entityName>::class)->setIdGeneratorType(ClassMetadata::GENERATOR_TYPE_NONE);
 <spaces><fixtures>
 <spaces>
 <spaces><spaces>$manager->flush();


### PR DESCRIPTION
This PR fixes the error below of incompatible interface for Symfony 4+

In DoctrineFixtureGenerator.php line 48:
                                                                                                                                                                       
  Argument 2 passed to Webonaute\DoctrineFixturesGeneratorBundle\Generator\DoctrineFixtureGenerator::__construct() must be an instance of Symfony\Bridge\Doctrine\Reg  
  istryInterface, instance of Doctrine\Bundle\DoctrineBundle\Registry given, called in /var/www/vendor/webonaute/doctrine-fixtures-generator-bundle/Webonaute/Doctrin  
  eFixturesGeneratorBundle/Command/GenerateDoctrineFixtureCommand.php on line 129         